### PR TITLE
fix spacing and min app version

### DIFF
--- a/include/app.inc
+++ b/include/app.inc
@@ -30,7 +30,7 @@ macro app_private
 	local app
 	element app.base
 
-	min_version := '5.0.0.0.0'
+	min_version := '5.0.0.0000'
 
 	postpone
 		virtual

--- a/src/view-vat-items.asm
+++ b/src/view-vat-items.asm
@@ -39,7 +39,7 @@ view_vat_items:
 	call	gui_draw_static_options
 	ld	hl,sprite_egg
 	draw_sprite_2x 120, 57
-	print	string_new_prgm, 199, 194
+	print	string_new_prgm, 199, 195
 	ld	de,287
 .no_new:
 	ld	(lcd_x),de
@@ -390,7 +390,7 @@ tmp_y := $-1
 	print string_locked, 199, 129
 	print string_hidden, 199, 140
 
-	print string_rename, 199, 194
+	print string_rename, 199, 195
 	ld	de,262
 	ld	(lcd_x),de
 	inc	hl
@@ -398,11 +398,11 @@ tmp_y := $-1
 
 	bit	prgm_locked,(iy + prgm_flag)
 	jr	nz,.is_locked
-	print	string_edit_prgm, 199, 183
+	print	string_edit_prgm, 199, 184
 	ld	de,269
 	jr	.no_new
 .is_locked:
-	print	string_new_prgm, 199, 183
+	print	string_new_prgm, 199, 184
 	ld	de,287
 .no_new:
 	ld	(lcd_x),de


### PR DESCRIPTION
Not sure if changing the minimum app version to be consistent with every other app will negatively effect anything, but I've been doing it for a while with no noticeable issues.
Also fixed the annoying spacing in the All programs options.