### PR TITLE
Fix brightness controls in settings

### DIFF
--- a/src/settings.asm
+++ b/src/settings.asm
@@ -253,7 +253,7 @@ setting_up:
 
 setting_left:
 	ld	a,(ix)
-	cp	a,7
+	cp	a,8
 	jq	z,setting_brightness_down
 	jq	settings_switch_page
 
@@ -265,7 +265,7 @@ setting_brightness_down:
 
 setting_right:
 	ld	a,(ix)
-	cp	a,7
+	cp	a,8
 	jq	z,setting_brightness_up
 	jq	settings_switch_page
 


### PR DESCRIPTION
So the brightness controls are on line 8 (`Change screen brightness`) and not line 7 (`Show confirm deletion prompt`).