### PR TITLE
Italian language bugfix

### DIFF
--- a/src/installer.asm
+++ b/src/installer.asm
@@ -147,7 +147,7 @@ str_invalid_os_install:
 str_cesium_installed:
 	db 'Installato nel menu ',$C1,'apps]',0
 str_cesium_exists_error:
-	db 'Cesium è già installato, eliminalo prima di reinstallarlo.',0
+	db 'Cesium e gia installato,  eliminalo prima di reinstallarlo.',0
 str_delete_installer:
 	db 'Eliminare l',$27,'installer?', 0
 	db 'del - si',0

--- a/src/strings.asm
+++ b/src/strings.asm
@@ -529,7 +529,7 @@ string_rename:
 	db	'Rinomina',0
 	db	$7e,'GRAPH]',0
 string_transfer:
-	db	'Transferisci',0
+	db	'Transf.',0
 	db	$7e,'PRGM]',0
 string_edit_prgm:
 	db	'Modifica',0
@@ -552,7 +552,7 @@ string_setting_indicator:
 string_setting_clock:
 	db	'Mostra l',$27,'orologio',0
 string_setting_show_battery:
-	db	'Mostra stato della batteria',0
+	db	'Mostra lo stato della batteria',0
 string_setting_show_hidden:
 	db	'Nascondi i programmi nascosti',0
 string_setting_ram_backup:
@@ -616,6 +616,6 @@ string_ram_error:
 str_invalid_os:
 	db	'Impossibile usare questo OS',0
 str_cannot_hide:
-	db	'Impossibile mostrare/nascondere programmi archiviati',0
+	db	'Impos. mostrare/nascondere prgm archiv.',0
 
 end if


### PR DESCRIPTION
**src/strings.asm:**
fixed `str_cannot_hide` being too long and overflowing the screen
fixed `string_transfer` being too long and overlapping with the [PRGM] text

**src/installer.asm:**
Fixed `str_cesium_exists_error` using accents

**Other**
Further tested the USB text